### PR TITLE
Expose RAG DB to self-hosted Ollama

### DIFF
--- a/agentic-rag-docs/self-host.md
+++ b/agentic-rag-docs/self-host.md
@@ -70,7 +70,11 @@ docker run -d --name ollama \
   --gpus all --restart unless-stopped \
   -p <remote-port>:11434 \
   -v ollama_data:/root/.ollama \
+  -v /path/to/project/data:/project/data \
   ollama/ollama:latest
+
+# The additional volume mount exposes your project's RAG database directory
+# to the Ollama container so it can be used during retrieval.
 
 # Make sure it is running properly
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,6 +17,9 @@ services:
       - type: volume
         source: ollama_data
         target: /root/.ollama
+      - type: bind
+        source: ./data
+        target: /project/data
 
 networks:
   default:


### PR DESCRIPTION
## Summary
- mount the project's data folder into the Ollama container so the LLM can read the RAG database
- document the new volume mount in the self-host instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687150975ecc832a933d09ae86824c41